### PR TITLE
Add 0 default to as_timestamp filter to avoid complaints when the val…

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ The binary sensors has an `ON` or `OFF` state and includes attributes for the st
     - name: "Power Up In Progress"
       state: >
         {% set n = now() | as_timestamp %}
-        {% set st  = state_attr('sensor.power_up_times', 'start') | as_timestamp %}
-        {% set end = state_attr('sensor.power_up_times', 'end')   | as_timestamp %}
+        {% set st  = state_attr('sensor.power_up_times', 'start') | as_timestamp(0) %}
+        {% set end = state_attr('sensor.power_up_times', 'end')   | as_timestamp(0) %}
         {% if n >= st and n < end %}
           True
         {% else %}
@@ -79,13 +79,13 @@ The binary sensors has an `ON` or `OFF` state and includes attributes for the st
         {% endif %}
       attributes:
         duration_mins: >
-          {% set st  = state_attr('sensor.power_up_times', 'start') | as_timestamp %}
-          {% set end = state_attr('sensor.power_up_times', 'end')   | as_timestamp %}
+          {% set st  = state_attr('sensor.power_up_times', 'start') | as_timestamp(0) %}
+          {% set end = state_attr('sensor.power_up_times', 'end')   | as_timestamp(0) %}
           {{ ((end - st) / 60) | int }}
         duration_remaining: >
           {% if this.state == 'on' %}
             {% set n = now() | as_timestamp %}
-            {% set end = state_attr('sensor.power_up_times', 'end') | as_timestamp %}
+            {% set end = state_attr('sensor.power_up_times', 'end') | as_timestamp(0) %}
             {{ ((end - n) / 60) | int }}
           {% else %}
             {{ False }}

--- a/README.md
+++ b/README.md
@@ -68,14 +68,17 @@ The binary sensors has an `ON` or `OFF` state and includes attributes for the st
 [//]: # ({% raw %})
 ```
     - name: "Power Up In Progress"
+
       state: >
         {% set n = now() | as_timestamp %}
-        {% set st  = state_attr('sensor.power_up_times', 'start') | as_timestamp(0) %}
-        {% set end = state_attr('sensor.power_up_times', 'end')   | as_timestamp(0) %}
-        {% if n >= st and n < end %}
-          True
-        {% else %}
-          False
+        {% set st  = state_attr('sensor.power_up_times', 'start') %}
+        {% set end = state_attr('sensor.power_up_times', 'end')  %}
+        {% if st != none %}
+          {% if n >= as_timestamp(st) and n < as_timestamp(end) %}
+            True
+          {% else %}
+             False
+          {% endif %}
         {% endif %}
       attributes:
         duration_mins: >


### PR DESCRIPTION
…ues returned from the JSON are null.

First of all thanks for this! I had been wondering if Octopus would add API support at some point or if someone else had figured this out, googled just in case, found your repo.

When setting this up, I noticed that at least when using the free sessions endpoint, the binary sensor template doesn't like getting a 'null' value so was complaining, leading to unavailable rather than on/off. I've added a 0 default to the as_timestamp calls which still results in the correct true/false response. I skipped using the attributes locally, just added the binary section, not really sure 0 is a great default for those.

Barely beyond an HA templating novice so there might be a cleaner approach here, and I've got it working for me (or at least when there's no powerup, next one is in three hours so I'll find out then), so no worries if you'd rather not account for this too.